### PR TITLE
restore BWS url option (do not hard-code)

### DIFF
--- a/angular-bitcore-wallet-client/index.js
+++ b/angular-bitcore-wallet-client/index.js
@@ -34,7 +34,7 @@ bwcModule.provider("bwcService", function() {
 
       //note opts use `bwsurl` all lowercase;
       var bwc = new Client({
-        baseUrl: 'https://bws.dashevo.org/bws/api',
+        baseUrl: opts.bwsurl || 'https://bws.dashevo.org/bws/api',
         verbose: opts.verbose,
         timeout: 100000,
         transports: ['polling'],


### PR DESCRIPTION
This was removed in commit a72a79fb93f8dda5b4b5bf3bcd7a72f21a7c8f21,
probably an oversight.