### PR TITLE
remove window.instantSend logic

### DIFF
--- a/src/bitcore-wallet-client/lib/api.js
+++ b/src/bitcore-wallet-client/lib/api.js
@@ -2126,9 +2126,6 @@ API.prototype.broadcastRawTx = function(opts, cb) {
 API.prototype._doBroadcast = function(txp, cb) {
   var self = this;
   var url = '/v1/txproposals/' + txp.id + '/broadcast/';
-  if(window.instantSend) {
-    url = 'http://testnet-insight.dashevo.org/insight-api-dash/tx/sendix'
-  }
   self._doPostRequest(url, {}, function(err, txp) {
     if (err) return cb(err);
     self._processTxps(txp);


### PR DESCRIPTION
Review indicates that this code is unnecessary and that it is already being handled by BWS.

When a TXP (Transaction Proposal) is created, a boolean value is assigned to "isInstantSend". Depending on this value BWS will handle the transaction as either InstantSend or as a normal raw broadcast. This logic can be found at https://github.com/snogcel/bitcore-wallet-service-dash/blob/master_upstream/lib/server.js#L2774-L2797. 