### PR TITLE
Bugfix: transaction history shows only today's transactions

### DIFF
--- a/src/js/services/profileService.js
+++ b/src/js/services/profileService.js
@@ -804,6 +804,7 @@ angular.module('copayApp.services')
       opts = opts || {};
 
       var TIME_STAMP = 60 * 60 * 24 * 7
+      var MAX = 30
 
       var typeFilter = {
         'NewOutgoingTx': 1,


### PR DESCRIPTION
Caused because of:
1. wrong time interval - should be 7 days, not 6 hours
2. slice of activity array, not notification array