### PR TITLE
fix: hide coin selector dropdown menu

### DIFF
--- a/www/views/includes/cash.html
+++ b/www/views/includes/cash.html
@@ -1,9 +1,0 @@
-<label class="item item-input item-select">
-  <div class="input-label" translate>
-    Coin
-  </div>
-  <select ng-model="formData.coin" ng-change="switchTestnetOff()">
-    <option value="btc">BTC</option>
-    <option value="bch">BCH</option>
-  </select>
-</label>

--- a/www/views/join.html
+++ b/www/views/join.html
@@ -32,8 +32,6 @@
           </div>
         </div>
 
-        <!-- <div ng-include="'views/includes/cash.html'"></div> -->
-
         <div class="item item-divider"></div>
 
         <a class="item" ng-click="showAdvChange()">

--- a/www/views/tab-create-personal.html
+++ b/www/views/tab-create-personal.html
@@ -14,8 +14,6 @@
             ng-focus="formFocus('wallet-name')" ng-blur="formFocus(false)" required>
         </label>
 
-        <!-- <div ng-include="'views/includes/cash.html'"></div> -->
-
         <div class="item item-divider"></div>
 
         <a class="item" ng-click="showAdvChange()">

--- a/www/views/tab-create-shared.html
+++ b/www/views/tab-create-shared.html
@@ -20,8 +20,6 @@
             ng-focus="formFocus('my-name')" ng-blur="formFocus(false)">
         </label>
 
-        <!-- <div ng-include="'views/includes/cash.html'"></div> -->
-
         <label class="item item-input item-select">
           <div class="input-label" translate>
             Total number of copayers

--- a/www/views/tab-import-file.html
+++ b/www/views/tab-import-file.html
@@ -21,8 +21,6 @@
         ng-model="formData.password">
     </label>
 
-    <!-- <div ng-include="'views/includes/cash.html'"></div> -->
-
     <div class="item item-divider"></div>
 
     <a class="item" ng-click="showAdvChange()">

--- a/www/views/tab-import-phrase.html
+++ b/www/views/tab-import-phrase.html
@@ -27,8 +27,6 @@
       </div>
     </div>
 
-    <!-- <div ng-include="'views/includes/cash.html'"></div> -->
-
     <div class="item item-divider"></div>
 
     <a class="item" ng-click="showAdvChange()">


### PR DESCRIPTION
This PR address DMD-188 and hides the coin selector dropdown menu. This dropdown allows the user to override the default coin value and can be safely hidden.