### PR TITLE
Replacement of cordova clipboard plugin

### DIFF
--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -48,7 +48,7 @@
     <plugin name="cordova-plugin-statusbar" spec="2.3.0" />
     <plugin name="cordova-plugin-inappbrowser" spec="1.7.2" />
     <plugin name="cordova-plugin-x-toast" spec="2.6.0" />
-    <plugin name="cordova-clipboard" spec="1.1.0" />
+    <plugin name="cordova-clipboard" spec="https://github.com/ihadeed/cordova-clipboard" />
     <plugin name="cordova-plugin-x-socialsharing" spec="5.2.1" />
     <plugin name="cordova-plugin-spinner-dialog" spec="1.3.1" />
     <plugin name="cordova-plugin-dialogs" spec="1.3.4" />


### PR DESCRIPTION
Previously used plugin is outdated and doesn't work with latest iOS.