### PR TITLE
Wrong URL when tapping on Insufficient funds

### DIFF
--- a/src/js/controllers/confirm.js
+++ b/src/js/controllers/confirm.js
@@ -32,7 +32,7 @@ angular.module('copayApp.controllers').controller('confirmController', function(
   }
 
   $scope.openSupport = function() {
-    var url = 'https://support.bitpay.com/hc/en-us/articles/115005936786';
+    var url = 'https://www.dash.org/get-dash/';
     externalLinkService.open(url);
   };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7160998/42630135-64df5c5c-85de-11e8-8712-eaf177e4b6ac.png)

Just try to send 1000000 dash to any contact to reproduce