### PR TITLE
Request specific amount confirmation step: btc is shown fix

### DIFF
--- a/src/js/services/txFormatService.js
+++ b/src/js/services/txFormatService.js
@@ -231,7 +231,7 @@ angular.module('copayApp.services').factory('txFormatService', function($filter,
       currency: currency,
       alternativeIsoCode: alternativeIsoCode,
       amountSat: amountSat,
-      amountUnitStr: amountUnitStr
+      amountUnitStr: amountUnitStr.replace('btc', 'DASH')
     };
   };
 


### PR DESCRIPTION
Dirty fix, but as soon as we use 'btc' as coin everywhere, don't want to break functionality before the release